### PR TITLE
self-throttle in instances of excessive cpu/memory usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 DEVELOPMENT_REQUIREMENTS = [
     "pytest",
     "coverage",
@@ -27,7 +27,7 @@ setup(
     url="https://github.com/goodmanship/sqsworkers",
     author="Rio Goodman",
     author_email="riogoodman@gmail.com",
-    install_requires=["boto3", "dataclasses"],
+    install_requires=["boto3", "dataclasses", "psutil"],
     extras_require={
         "dev": DEVELOPMENT_REQUIREMENTS,
         "test": DEVELOPMENT_REQUIREMENTS,

--- a/sqsworkers/base.py
+++ b/sqsworkers/base.py
@@ -197,7 +197,9 @@ class BaseListener(interfaces.CrewInterface):
 
             if cpu_usage_percent >= 85 or memory_usage_percent >= 85:
                 logging.debug(
-                    f"(cpu,memory) usage at ({cpu_usage_percent},{memory_usage_percent}) -- skipping poll on sqs"
+                    "(cpu,memory) usage at ({cpu_usage_percent},{memory_usage_percent}) -- skipping poll on sqs".format(
+                        **locals()
+                    )
                 )
                 continue
 

--- a/sqsworkers/base.py
+++ b/sqsworkers/base.py
@@ -192,11 +192,12 @@ class BaseListener(interfaces.CrewInterface):
 
         while True:
 
-            cpu_percent = psutil.cpu_percent()
+            cpu_usage_percent = psutil.cpu_percent()
+            memory_usage_percent = psutil.virtual_memory().percent
 
-            if cpu_percent >= 85:
+            if cpu_usage_percent >= 85 or memory_usage_percent >= 85:
                 logging.debug(
-                    f"cpu usage at {cpu_percent} -- skipping poll on sqs"
+                    f"(cpu,memory) usage at ({cpu_usage_percent},{memory_usage_percent}) -- skipping poll on sqs"
                 )
                 continue
 

--- a/sqsworkers/crew.py
+++ b/sqsworkers/crew.py
@@ -117,7 +117,9 @@ class BulkListener(BaseListener):
 
             if cpu_usage_percent >= 85 or memory_usage_percent >= 85:
                 logging.debug(
-                    f"(cpu,memory) usage at ({cpu_usage_percent},{memory_usage_percent}) -- skipping poll on sqs"
+                    "(cpu,memory) usage at ({cpu_usage_percent},{memory_usage_percent}) -- skipping poll on sqs".format(
+                        **locals()
+                    )
                 )
                 continue
 

--- a/sqsworkers/crew.py
+++ b/sqsworkers/crew.py
@@ -6,6 +6,8 @@ from functools import partial
 from threading import Thread
 from typing import *
 
+import psutil
+
 from sqsworkers import MessageMetadata
 from sqsworkers import interfaces
 from sqsworkers.base import BaseListener
@@ -109,6 +111,13 @@ class BulkListener(BaseListener):
 
     def start(self):
         while True:
+            cpu_percent = psutil.cpu_percent()
+
+            if cpu_percent >= 85:
+                logging.debug(
+                    f"cpu usage at {cpu_percent} -- skipping poll on sqs"
+                )
+                continue
 
             if self.minimum_messages:
                 messages = []

--- a/sqsworkers/crew.py
+++ b/sqsworkers/crew.py
@@ -111,6 +111,7 @@ class BulkListener(BaseListener):
 
     def start(self):
         while True:
+
             cpu_usage_percent = psutil.cpu_percent()
             memory_usage_percent = psutil.virtual_memory().percent
 

--- a/sqsworkers/crew.py
+++ b/sqsworkers/crew.py
@@ -111,11 +111,12 @@ class BulkListener(BaseListener):
 
     def start(self):
         while True:
-            cpu_percent = psutil.cpu_percent()
+            cpu_usage_percent = psutil.cpu_percent()
+            memory_usage_percent = psutil.virtual_memory().percent
 
-            if cpu_percent >= 85:
+            if cpu_usage_percent >= 85 or memory_usage_percent >= 85:
                 logging.debug(
-                    f"cpu usage at {cpu_percent} -- skipping poll on sqs"
+                    f"(cpu,memory) usage at ({cpu_usage_percent},{memory_usage_percent}) -- skipping poll on sqs"
                 )
                 continue
 


### PR DESCRIPTION
In order to facilitate embarrassingly parallel polling on a single sqs queue from multiple threads without overloading the machine's cpu and memory constraints, this PR makes it so the `Listener` classes will **skip** on polling the queue **if cpu or memory usage is >= 85%** for each iteration of its `while` loop 