### PR TITLE
remove noise from failure logs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 DEVELOPMENT_REQUIREMENTS = [
     "pytest",
     "coverage",

--- a/sqsworkers/crew.py
+++ b/sqsworkers/crew.py
@@ -224,16 +224,18 @@ class BulkListener(BaseListener):
                 "process.record.success", len(result.succeeded), tags=[]
             )
 
-            self.logger.error(
-                "failed to process {} messages: {metadata}".format(
-                    len(result.failed),
-                    metadata=[MessageMetadata(m) for m in result.failed],
-                )
-            )
+            if result.failed:
 
-            self.statsd.increment(
-                "process.record.failure", len(result.failed), tags=[]
-            )
+                self.logger.error(
+                    "failed to process {} messages: {metadata}".format(
+                        len(result.failed),
+                        metadata=[MessageMetadata(m) for m in result.failed],
+                    )
+                )
+
+                self.statsd.increment(
+                    "process.record.failure", len(result.failed), tags=[]
+                )
 
             # make sure we don't try to delete more than 10 messages
             # at a time or we'll get an error from boto3


### PR DESCRIPTION
* previously, if no errors were raised during batch processing, a `failed to process 0 messages...` event was logged at the `ERROR` level. This prevents that from happening